### PR TITLE
Add social preview metadata

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,8 +15,31 @@ const sourceCodePro = Source_Code_Pro({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://unicrnmafia.com"),
   title: "Unicorn Mafia",
   description: "The highest signal community of developers in London",
+  openGraph: {
+    title: "Unicorn Mafia",
+    description: "The highest signal community of developers in London",
+    url: "https://unicrnmafia.com",
+    siteName: "Unicorn Mafia",
+    images: [
+      {
+        url: "/hero.avif",
+        width: 841,
+        height: 686,
+        alt: "Unicorn Mafia hero image",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Unicorn Mafia",
+    description: "The highest signal community of developers in London",
+    images: ["/hero.avif"],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add Open Graph/Twitter metadata in `layout.tsx` so links show a preview image

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_688799461e6c83228f42749b3c3aab88