### PR TITLE
Add companies page with YAML data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Thanks for your interest in contributing to the Unicorn Mafia website.
+
+## Adding your company
+
+Member companies can appear on the site by adding an entry to [`public/companies.yaml`](public/companies.yaml). The file is structured as a set of *domains* containing *categories*. Each category lists a set of tools (companies) with the following fields:
+
+```yaml
+{
+  "name": "Your Company",
+  "icon_url": "/companies/your-logo.svg",
+  "website_url": "https://example.com",
+  "description": "Optional short description"
+}
+```
+
+1. Copy your company logo into `public/companies/` in **SVG** format.
+2. Add a new object under the appropriate category in `public/companies.yaml` referencing the logo path and your website.
+3. Commit your changes and open a pull request.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+Please run `npm run lint` and `npm run build` before submitting a PR.

--- a/public/companies.yaml
+++ b/public/companies.yaml
@@ -1,0 +1,42 @@
+{
+  "domains": [
+    {
+      "name": "Members",
+      "categories": [
+        {
+          "name": "Companies",
+          "description": "Companies building with Unicorn Mafia hackers.",
+          "level": 1,
+          "tools": [
+            { "name": "Amazon", "icon_url": "/companies/amazon.svg", "website_url": "https://amazon.com" },
+            { "name": "Anthropic", "icon_url": "/companies/anthropic.svg", "website_url": "https://www.anthropic.com" },
+            { "name": "Apple", "icon_url": "/companies/apple.svg", "website_url": "https://apple.com" },
+            { "name": "Google", "icon_url": "/companies/google.svg", "website_url": "https://google.com" },
+            { "name": "Meta", "icon_url": "/companies/meta.svg", "website_url": "https://about.meta.com" },
+            { "name": "Nvidia", "icon_url": "/companies/nvidia.svg", "website_url": "https://www.nvidia.com" },
+            { "name": "OpenAI", "icon_url": "/companies/openai.svg", "website_url": "https://openai.com" }
+          ]
+        },
+        {
+          "name": "Universities",
+          "description": "Top universities represented by our community.",
+          "level": 1,
+          "tools": [
+            { "name": "Cambridge", "icon_url": "/companies/cambridge.svg", "website_url": "https://www.cam.ac.uk" },
+            { "name": "Imperial", "icon_url": "/companies/imperial.svg", "website_url": "https://www.imperial.ac.uk" },
+            { "name": "Oxford", "icon_url": "/companies/oxford.svg", "website_url": "https://www.ox.ac.uk" },
+            { "name": "UCL", "icon_url": "/companies/ucl.svg", "website_url": "https://www.ucl.ac.uk" }
+          ]
+        },
+        {
+          "name": "Investors",
+          "description": "Accelerators and investors backing our builders.",
+          "level": 1,
+          "tools": [
+            { "name": "Y Combinator", "icon_url": "/companies/ycombinator.svg", "website_url": "https://www.ycombinator.com" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/app/_components/navbar/navbar.tsx
+++ b/src/app/_components/navbar/navbar.tsx
@@ -63,7 +63,7 @@ export default function Navbar() {
           >
             <Link href="#about" className="hover:opacity-70 transition-opacity">About</Link>
             <Link href="#hackathons" className="hover:opacity-70 transition-opacity">Hackathons</Link>
-            <Link href="#companies" className="hover:opacity-70 transition-opacity">Companies</Link>
+            <Link href="/companies" className="hover:opacity-70 transition-opacity">Companies</Link>
             <Link href="#contact" className="hover:opacity-70 transition-opacity">Contact</Link>
           </div>
           <div className="relative w-[18px] h-[18px] flex-none cursor-pointer">
@@ -97,6 +97,13 @@ export default function Navbar() {
             onClick={() => setToggle(false)}
           >
             About
+          </Link>
+          <Link
+            href="/companies"
+            className="hover:opacity-70 transition-opacity"
+            onClick={() => setToggle(false)}
+          >
+            Companies
           </Link>
           <Link
             href="#contact"

--- a/src/app/_components/trustby/trustby.tsx
+++ b/src/app/_components/trustby/trustby.tsx
@@ -6,22 +6,11 @@ import { InfiniteSlider } from '../ui/infinite-slider';
 import { useScrollAnimation } from '../../_hooks/useScrollAnimation';
 import animationStyles from '../../_styles/animations.module.css';
 
-const companies = [
-  { name: 'Amazon', logo: '/companies/amazon.svg' },
-  { name: 'Anthropic', logo: '/companies/anthropic.svg' },
-  { name: 'Apple', logo: '/companies/apple.svg' },
-  { name: 'Cambridge', logo: '/companies/cambridge.svg' },
-  { name: 'Google', logo: '/companies/google.svg' },
-  { name: 'Imperial', logo: '/companies/imperial.svg' },
-  { name: 'Meta', logo: '/companies/meta.svg' },
-  { name: 'Nvidia', logo: '/companies/nvidia.svg' },
-  { name: 'OpenAI', logo: '/companies/openai.svg' },
-  { name: 'Oxford', logo: '/companies/oxford.svg' },
-  { name: 'UCL', logo: '/companies/ucl.svg' },
-  { name: 'Y Combinator', logo: '/companies/ycombinator.svg' },
-];
-
-export default function TrustBy() {
+export type Company = {
+  name: string;
+  logo: string;
+};
+export default function TrustBy({ companies }: { companies: Company[] }) {
   const [ref, isVisible] = useScrollAnimation();
 
   return (

--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -1,0 +1,86 @@
+import Navbar from "../_components/navbar/navbar";
+import Image from "next/image";
+import Link from "next/link";
+import fs from "fs/promises";
+import path from "path";
+
+export const metadata = {
+  title: "Member Companies - Unicorn Mafia",
+};
+
+type Tool = {
+  name: string;
+  icon_url: string;
+  website_url: string;
+};
+
+type Category = {
+  name: string;
+  tools: Tool[];
+};
+
+type Domain = {
+  name: string;
+  categories: Category[];
+};
+
+async function getData(): Promise<{ domains: Domain[] }> {
+  const file = await fs.readFile(
+    path.join(process.cwd(), "public", "companies.yaml"),
+    "utf8"
+  );
+  return JSON.parse(file) as { domains: Domain[] };
+}
+
+export default async function CompaniesPage() {
+  const data = await getData();
+  const allTools = data.domains.flatMap((domain) =>
+    domain.categories.flatMap((category) =>
+      category.tools.map((tool) => ({
+        ...tool,
+        domainName: domain.name,
+        categoryName: category.name,
+      }))
+    )
+  );
+
+  return (
+    <div className="flex flex-col items-center">
+      <Navbar />
+      <div className="w-full px-6 md:px-12 lg:px-20 py-16">
+        <table className="w-full text-left border-collapse">
+          <thead>
+            <tr className="border-b">
+              <th className="py-2 px-4">Logo</th>
+              <th className="py-2 px-4">Name</th>
+              <th className="py-2 px-4">Domain</th>
+              <th className="py-2 px-4">Category</th>
+              <th className="py-2 px-4">Website</th>
+            </tr>
+          </thead>
+          <tbody>
+            {allTools.map((tool) => (
+              <tr key={`${tool.domainName}-${tool.categoryName}-${tool.name}`} className="border-b">
+                <td className="py-2 px-4">
+                  {tool.icon_url && (
+                    <div className="relative w-10 h-10">
+                      <Image src={tool.icon_url} alt={tool.name} fill className="object-contain" />
+                    </div>
+                  )}
+                </td>
+                <td className="py-2 px-4">{tool.name}</td>
+                <td className="py-2 px-4">{tool.domainName}</td>
+                <td className="py-2 px-4">{tool.categoryName}</td>
+                <td className="py-2 px-4">
+                  <Link href={tool.website_url} target="_blank" rel="noopener noreferrer">
+                    {tool.website_url.replace(/^https?:\/\//, '').replace(/\/$/, '')}
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,33 @@
 import Hero from "./_components/hero/hero";
 import Navbar from "./_components/navbar/navbar";
-import TrustBy from "./_components/trustby/trustby";
+import TrustBy, { Company } from "./_components/trustby/trustby";
 import About from "./_components/about/about";
 import Contact from "./_components/contact/contact";
-export default function Home() {
+import fs from "fs/promises";
+import path from "path";
+
+async function getCompanies(): Promise<Company[]> {
+  const file = await fs.readFile(
+    path.join(process.cwd(), "public", "companies.yaml"),
+    "utf8"
+  );
+  const data = JSON.parse(file) as {
+    domains: { categories: { tools: { name: string; icon_url: string }[] }[] }[];
+  };
+  return data.domains.flatMap((d) =>
+    d.categories.flatMap((c) =>
+      c.tools.map((t) => ({ name: t.name, logo: t.icon_url }))
+    )
+  );
+}
+
+export default async function Home() {
+  const companies = await getCompanies();
   return (
     <div className="flex flex-col items-center">
       <Navbar />
       <Hero />
-      <TrustBy />
+      <TrustBy companies={companies} />
       <About />
       <Contact />
     </div>


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guidelines
- store company info in `public/companies.yaml`
- load company logos from YAML on the homepage
- add `/companies` page displaying logo table
- link companies page from the navbar

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d4d2f8fc8322bd77d3645129fdf3