### PR TITLE
Create hackathons page from yaml

### DIFF
--- a/public/hackathons-data.yaml
+++ b/public/hackathons-data.yaml
@@ -1,0 +1,30 @@
+categories:
+  - name: AI & ML
+    description: Machine learning and AI-focused hackathons
+    wins:
+      - event_name: Example Hackathon
+        project_name: Smart Unicorn
+        prize: Grand Prize
+        year: 2025
+        members:
+          - Alice Example
+          - Bob Example
+        project_url: https://example.com/smart-unicorn
+        repo_url: https://github.com/example/smart-unicorn
+        logo_url: https://www.recurse.ml/static/logo.png
+        location: Remote
+        tags: [ai, ml]
+  - name: Fintech
+    description: Finance and blockchain related hackathons
+    wins:
+      - event_name: Chain Sprint
+        project_name: ClearPay
+        prize: Best Use of API
+        year: 2024
+        members:
+          - Charlie Example
+        project_url: https://t1v.co
+        repo_url: https://github.com/example/clearpay
+        logo_url: https://t1v.co/wp-content/uploads/2021/10/t1v-logo.png
+        tags: [fintech, blockchain]
+

--- a/src/app/_components/hackathons/add-yours-card.tsx
+++ b/src/app/_components/hackathons/add-yours-card.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+
+export function AddYoursCard() {
+  return (
+    <Link
+      href="https://github.com/unicorn-mafia/unicorn-mafia"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block aspect-square border border-neutral-600 bg-white hover:bg-neutral-100 transition-colors group"
+    >
+      <div className="h-full flex flex-col items-center justify-center p-4 text-center">
+        <div className="w-10 h-10 mb-2 rounded-full border border-neutral-600 flex items-center justify-center bg-neutral-50">
+          <span className="text-xl leading-none">+</span>
+        </div>
+        <div className="px-2">
+          <h3 className="text-[11px] font-source font-medium text-neutral-900 tracking-wide leading-tight">
+            ADD YOUR HACKATHON WIN
+          </h3>
+          <p className="mt-1 text-[9px] text-neutral-700 leading-snug">
+            Contribute via GitHub
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+

--- a/src/app/_components/hackathons/hackathon-card.tsx
+++ b/src/app/_components/hackathons/hackathon-card.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import Link from "next/link";
+import type { HackathonWinWithCategory } from "../../_types/hackathons";
+
+interface HackathonCardProps {
+  win: HackathonWinWithCategory;
+}
+
+export function HackathonCard({ win }: HackathonCardProps) {
+  const href = win.project_url || win.repo_url || "#";
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block aspect-square border border-neutral-600 bg-neutral-50 hover:bg-neutral-100 transition-colors group"
+    >
+      <div className="h-full flex flex-col">
+        <div className="flex-1 flex items-center justify-center p-4">
+          <div className="w-20 h-20 relative">
+            <Image
+              src={win.logo_url}
+              alt={`${win.project_name} logo`}
+              fill
+              className="object-contain"
+              onError={(e) => {
+                e.currentTarget.src = "/companies/placeholder-logo.svg";
+              }}
+            />
+          </div>
+        </div>
+        <div className="border-t border-neutral-400 px-1 py-2 text-center">
+          <h3 className="text-[10px] font-source font-medium text-neutral-900 tracking-wide leading-none truncate group-hover:text-neutral-700">
+            {`${win.project_name.toUpperCase()} · ${win.prize.toUpperCase()}`}
+          </h3>
+          <p className="mt-1 text-[9px] text-neutral-700 leading-none truncate">
+            {`${win.event_name} ${win.year}`}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
+}
+

--- a/src/app/_components/navbar/navbar.tsx
+++ b/src/app/_components/navbar/navbar.tsx
@@ -62,7 +62,7 @@ export default function Navbar() {
             `}
           >
             <Link href="#about" className="hover:opacity-70 transition-opacity">About</Link>
-            <Link href="#hackathons" className="hover:opacity-70 transition-opacity">Hackathons</Link>
+            <Link href="/hackathons" className="hover:opacity-70 transition-opacity">Hackathons</Link>
             <Link href="/companies" className="hover:opacity-70 transition-opacity">Companies</Link>
             <Link href="#contact" className="hover:opacity-70 transition-opacity">Contact</Link>
           </div>
@@ -92,7 +92,7 @@ export default function Navbar() {
             About
           </Link>
           <Link
-            href="#hackathons"
+            href="/hackathons"
             className="hover:opacity-70 transition-opacity"
             onClick={() => setToggle(false)}
           >

--- a/src/app/_lib/hackathons-data.ts
+++ b/src/app/_lib/hackathons-data.ts
@@ -1,0 +1,24 @@
+import yaml from 'js-yaml';
+import type { HackathonsData } from '../_types/hackathons';
+
+export async function loadHackathonsData(): Promise<HackathonsData> {
+  try {
+    const response = await fetch('/hackathons-data.yaml');
+    if (!response.ok) {
+      throw new Error(`Failed to fetch hackathons data: ${response.statusText}`);
+    }
+
+    const yamlText = await response.text();
+    const data = yaml.load(yamlText) as HackathonsData;
+
+    if (!data || !data.categories || !Array.isArray(data.categories)) {
+      throw new Error('Invalid hackathons data structure');
+    }
+
+    return data;
+  } catch (error) {
+    console.error('Error loading hackathons data:', error);
+    throw error;
+  }
+}
+

--- a/src/app/_types/hackathons.ts
+++ b/src/app/_types/hackathons.ts
@@ -1,0 +1,28 @@
+export interface HackathonWin {
+  event_name: string;
+  project_name: string;
+  prize: string;
+  year: number;
+  members: string[];
+  project_url: string;
+  repo_url?: string;
+  logo_url: string;
+  location?: string;
+  date?: string;
+  tags?: string[];
+}
+
+export interface HackathonWinWithCategory extends HackathonWin {
+  categoryName: string;
+}
+
+export interface HackathonCategory {
+  name: string;
+  description: string;
+  wins: HackathonWin[];
+}
+
+export interface HackathonsData {
+  categories: HackathonCategory[];
+}
+

--- a/src/app/hackathons/page.tsx
+++ b/src/app/hackathons/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Navbar from "../_components/navbar/navbar";
+import { loadHackathonsData } from "../_lib/hackathons-data";
+import type { HackathonsData } from "../_types/hackathons";
+import { HackathonCard } from "../_components/hackathons/hackathon-card";
+import { AddYoursCard } from "../_components/hackathons/add-yours-card";
+
+export default function Hackathons() {
+  const [hackathonsData, setHackathonsData] = useState<HackathonsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await loadHackathonsData();
+        setHackathonsData(data);
+      } catch (error) {
+        console.error("Failed to load hackathons data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex flex-col bg-neutral-100">
+        <Navbar />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="border border-neutral-600 bg-neutral-50 p-6">
+            <div className="text-sm font-source tracking-wide text-neutral-900">LOADING HACKATHONS...</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!hackathonsData) {
+    return (
+      <div className="min-h-screen flex flex-col bg-neutral-100">
+        <Navbar />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="border border-neutral-600 bg-neutral-50 p-6">
+            <div className="text-sm font-source tracking-wide text-neutral-900">FAILED TO LOAD HACKATHONS DATA</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const allWins = hackathonsData.categories
+    .flatMap((category) =>
+      category.wins.map((win) => ({
+        ...win,
+        categoryName: category.name,
+      }))
+    )
+    .sort(() => Math.random() - 0.5);
+
+  return (
+    <div className="min-h-screen bg-neutral-100">
+      <Navbar />
+
+      <section className="py-8 px-6 md:px-12 lg:px-20 border-b border-neutral-600">
+        <div className="max-w-6xl mx-auto">
+          <div className="border border-neutral-600 bg-neutral-50 p-6">
+            <div className="mb-4">
+              <h1 className="text-2xl font-medium font-source text-neutral-900 tracking-wide">
+                HACKATHON WINS
+              </h1>
+            </div>
+            <p className="text-sm text-neutral-700 font-source max-w-2xl mb-4 leading-relaxed">
+              Awarded projects and wins by Unicorn Mafia members across hackathons.
+            </p>
+            <div className="text-xs font-source text-neutral-600 tracking-wide">
+              <span className="border border-neutral-400 px-2 py-1 bg-white">{allWins.length} WINS</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-8 px-6 md:px-12 lg:px-20">
+        <div className="max-w-6xl mx-auto">
+          {allWins.length === 0 ? (
+            <div className="text-center py-16">
+              <div className="border border-neutral-600 bg-neutral-50 p-8">
+                <h3 className="text-lg font-medium text-neutral-900 mb-2 font-source tracking-wide">
+                  NO HACKATHON WINS FOUND
+                </h3>
+                <p className="text-sm text-neutral-600 font-source">
+                  Check back soon as we add more wins.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+              <AddYoursCard />
+              {allWins.map((win) => (
+                <HackathonCard key={`${win.categoryName}-${win.project_name}-${win.event_name}`} win={win} />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Add a new `/hackathons` page to display member hackathon wins, loaded from a YAML file, including an 'Add yours' contribution card.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b9c641e-8c36-4e97-bb4c-46166d581065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b9c641e-8c36-4e97-bb4c-46166d581065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

