### PR TITLE
Add easter egg api endpoint

### DIFF
--- a/src/app/api/v1/route.ts
+++ b/src/app/api/v1/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+	return new NextResponse("https://github.com/unicorn-mafia", {
+		status: 200,
+		headers: { "content-type": "text/plain; charset=utf-8" },
+	});
+}
+
+export async function POST() {
+	return new NextResponse("unicorn mafia", {
+		status: 200,
+		headers: { "content-type": "text/plain; charset=utf-8" },
+	});
+}
+


### PR DESCRIPTION
Add `/api/v1/` easter egg API endpoint that returns a GitHub link on GET and 'unicorn mafia' on POST.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ae36ccf-5527-485e-8f14-b4a900330719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ae36ccf-5527-485e-8f14-b4a900330719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

