### PR TITLE
Update navbar toggle visibility for mobile devices

### DIFF
--- a/src/app/_components/navbar/navbar.tsx
+++ b/src/app/_components/navbar/navbar.tsx
@@ -87,7 +87,7 @@ export default function Navbar() {
             <Link href="/companies" className="hover:opacity-70 transition-opacity">Companies</Link>
             <Link href="/#contact" className="hover:opacity-70 transition-opacity">Contact</Link>
           </div>
-          <div className="relative w-[18px] h-[18px] flex-none cursor-pointer">
+          <div className="relative w-[18px] h-[18px] flex-none cursor-pointer md:hidden">
             <AnimatedToggle
               toggle={toggle}
               onToggle={() => setToggle(!toggle)}


### PR DESCRIPTION
This PR hides the mobile menu toggle on desktop devices as otherwise it is redundant

- Added 'md:hidden' class to the toggle button for better responsiveness
- Ensures the toggle is only visible on smaller screens

Before:

<img width="1452" height="743" alt="image" src="https://github.com/user-attachments/assets/7d64a6a0-eefc-4940-86d6-dc0a57f9820a" />


After:

<img width="1478" height="713" alt="image" src="https://github.com/user-attachments/assets/bdf86e5d-0858-492e-b2af-22c5c9000bde" />
