### PR TITLE
feat(spritegen): power evolution, game HUD, outfit preservation & brand backgrounds

### DIFF
--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -56,12 +56,13 @@ const POSES = [
   "a rising dragon punch — leaping upward with fist driving skyward, fully airborne and twisting",
 ];
 
-const OUTFITS = [
-  "neon-trimmed black leather jacket, ripped techwear cargo pants, chunky platform boots with neon piping, fingerless gloves — purple and cyan neon accents",
-  "sleeveless armoured vest with glowing circuit lines, high-waist tactical trousers, knee-high boots, arm wraps with neon strips — red and gold neon accents",
-  "hooded longcoat with neon trim, slim combat trousers, ankle boots, visor goggles pushed up on forehead — green and white neon accents",
-  "cropped tech jacket, techwear shorts over leggings, heavy boots, exposed glowing cybernetic arm detail — blue and magenta neon accents",
-  "trench coat with neon-lit panels, tactical belt, wide-leg combat trousers, steel-toe boots — orange and purple neon accents",
+// Neon accent colour sets — one is picked randomly to give each sprite variety
+const NEON_ACCENTS = [
+  "purple and cyan neon accents",
+  "red and gold neon accents",
+  "green and white neon accents",
+  "blue and magenta neon accents",
+  "orange and purple neon accents",
 ];
 
 // ── Evolution tiers — power level scales with hours into the hackathon ────────
@@ -116,7 +117,7 @@ function getPowerTier(hoursIn: number): PowerTier {
 
 function buildSpritePrompt(hoursIn: number, photoMode: "solo" | "team"): string {
   const poseDesc   = POSES[Math.floor(Math.random() * POSES.length)];
-  const outfitDesc = OUTFITS[Math.floor(Math.random() * OUTFITS.length)];
+  const accentDesc = NEON_ACCENTS[Math.floor(Math.random() * NEON_ACCENTS.length)];
   const tier       = getPowerTier(hoursIn);
 
   if (photoMode === "team") {
@@ -126,7 +127,7 @@ Render each person as their own distinct fighter standing side by side in a team
 
 Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). Each character is ${tier.powerDesc}.
 
-Outfits: Each fighter wears a variation of this style: ${outfitDesc}. Cyberpunk street fighter aesthetic — NOT karate gis or martial arts uniforms.
+Outfits: Preserve what each person is actually wearing in the photo, but reimagine it with cyberpunk street fighter flair — add ${accentDesc}, neon trim, tech panelling, armour plating, or glowing details while keeping the overall silhouette and style faithful to their real outfit. NOT karate gis or martial arts uniforms.
 
 Full team visible from head to toe. Exaggerated fighting game proportions on every fighter.
 
@@ -137,7 +138,7 @@ ${tier.styleExtra}`;
 
 Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). The character is ${tier.powerDesc}.
 
-Outfit: ${outfitDesc}. Cyberpunk street fighter aesthetic — NOT a karate gi or martial arts uniform.
+Outfit: Preserve what the person is actually wearing in the photo, but reimagine it with cyberpunk street fighter flair — add ${accentDesc}, neon trim, tech panelling, armour plating, or glowing details while keeping the overall silhouette and style faithful to their real outfit. NOT a karate gi or martial arts uniform.
 
 Pose: Mid-attack — ${poseDesc}. Full body visible from head to toe, attacking limb fully extended. Exaggerated fighting game proportions, motion energy on the attacking limb.
 

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -101,9 +101,9 @@ const POWER_TIERS: PowerTier[] = [
     // 23 h+ — Stage 4: God Mode
     label: "God Mode",
     powerDesc:
-      "an absolutely unhinged god-tier final form — the body has become mostly pure white-hot divine energy barely holding a human silhouette, limbs trailing massive cascading wings of fire and lightning, hair exploding upward into a towering inferno, eyes replaced by two blinding stars, the ground beneath them cracking and disintegrating, surrounded by a massive double aura of crackling electricity and holy light, so overwhelmingly powerful it looks like a final boss cutscene",
+      "peak god-tier street fighter — still fully human in their cyberpunk outfit, but radiating an enormous blinding white and gold aura that dwarfs their body, hair wild and floating upward with raw energy, eyes glowing solid white, crackling electricity dancing across every surface of their clothing, one step beyond super form but still grounded as a street fighter",
     styleExtra:
-      "Maximum intensity pixel art. Enormous explosive aura twice the size of the body. Giant lightning wings. Towering fire hair. Ground shatter effect beneath the feet. Blinding white and gold core radiating outward into deep violet and electric blue. This sprite should look completely unhinged — like a Street Fighter II final boss crossed with a Dragon Ball Ultra Instinct transformation. Push every visual element to the absolute extreme.",
+      "Bold black outlines, vibrant neon pixel art. Same cyberpunk clothing as the other stages — intact, recognisable outfit. Massive bright aura surrounding the whole body. Electricity sparking off the clothes. Glowing white eyes. NO wings, NO body transformation, NO angelic forms. Pure Street Fighter II style at its absolute peak power.",
   },
 ];
 

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -101,9 +101,9 @@ const POWER_TIERS: PowerTier[] = [
     // 23 h+ — Stage 4: God Mode
     label: "God Mode",
     powerDesc:
-      "transcendent god form — part human, part pure radiant force, body erupting with divine energy, ethereal light trails streaming behind every limb, face serene and all-knowing, so powerful the very pixels around them seem to crack and glow",
+      "an absolutely unhinged god-tier final form — the body has become mostly pure white-hot divine energy barely holding a human silhouette, limbs trailing massive cascading wings of fire and lightning, hair exploding upward into a towering inferno, eyes replaced by two blinding stars, the ground beneath them cracking and disintegrating, surrounded by a massive double aura of crackling electricity and holy light, so overwhelmingly powerful it looks like a final boss cutscene",
     styleExtra:
-      "Bold black outlines, vibrant neon pixel art at maximum intensity. Blinding white core with rainbow energy corona. Pixel art deity aesthetic — this character has ascended beyond human limits. Street Fighter II sprite style taken to godlike extremes.",
+      "Maximum intensity pixel art. Enormous explosive aura twice the size of the body. Giant lightning wings. Towering fire hair. Ground shatter effect beneath the feet. Blinding white and gold core radiating outward into deep violet and electric blue. This sprite should look completely unhinged — like a Street Fighter II final boss crossed with a Dragon Ball Ultra Instinct transformation. Push every visual element to the absolute extreme.",
   },
 ];
 

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -114,10 +114,24 @@ function getPowerTier(hoursIn: number): PowerTier {
   return POWER_TIERS[0];
 }
 
-function buildSpritePrompt(hoursIn: number): string {
+function buildSpritePrompt(hoursIn: number, photoMode: "solo" | "team"): string {
   const poseDesc   = POSES[Math.floor(Math.random() * POSES.length)];
   const outfitDesc = OUTFITS[Math.floor(Math.random() * OUTFITS.length)];
   const tier       = getPowerTier(hoursIn);
+
+  if (photoMode === "team") {
+    return `Using every person visible in this group photo as character references, create a 2D pixel art cyberpunk fighting game scene in the style of Street Fighter II. Pure black backdrop.
+
+Render each person as their own distinct fighter standing side by side in a team battle formation — all facing the same direction, each in a dynamic fighting stance. Keep each fighter's facial likeness and hair faithful to the person in the photo.
+
+Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). Each character is ${tier.powerDesc}.
+
+Outfits: Each fighter wears a variation of this style: ${outfitDesc}. Cyberpunk street fighter aesthetic — NOT karate gis or martial arts uniforms.
+
+Full team visible from head to toe. Exaggerated fighting game proportions on every fighter.
+
+${tier.styleExtra}`;
+  }
 
   return `Using the person in this photo as the character reference, create a 2D pixel art cyberpunk fighting game sprite in the style of Street Fighter II. Pure black backdrop.
 
@@ -168,7 +182,8 @@ export async function POST(req: NextRequest) {
     const formData = await req.formData();
     const file = formData.get("image") as File | null;
     const hoursIn = Math.max(0, Number(formData.get("hoursIn") ?? 0));
-    const SPRITE_PROMPT = buildSpritePrompt(hoursIn);
+    const photoMode = formData.get("photoMode") === "team" ? "team" : "solo";
+    const SPRITE_PROMPT = buildSpritePrompt(hoursIn, photoMode);
 
     if (!file) {
       return NextResponse.json(

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -123,13 +123,13 @@ function buildSpritePrompt(hoursIn: number, photoMode: "solo" | "team"): string 
   if (photoMode === "team") {
     return `Using every person visible in this group photo as character references, create a 2D pixel art cyberpunk fighting game scene in the style of Street Fighter II. Pure black backdrop.
 
-Render each person as their own distinct fighter standing side by side in a team battle formation — all facing the same direction, each in a dynamic fighting stance. Keep each fighter's facial likeness and hair faithful to the person in the photo.
+Render each person as their own distinct fighter standing side by side in a team battle formation — all facing the same direction, each in a dynamic fighting stance. Distinguish each fighter clearly with different hair, build, and stance matching the people in the photo.
 
 Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). Each character is ${tier.powerDesc}.
 
 Outfits: Preserve what each person is actually wearing in the photo, but reimagine it with cyberpunk street fighter flair — add ${accentDesc}, neon trim, tech panelling, armour plating, or glowing details while keeping the overall silhouette and style faithful to their real outfit. NOT karate gis or martial arts uniforms.
 
-Full team visible from head to toe. Exaggerated fighting game proportions on every fighter.
+All fighters fully visible from head to toe in a single wide scene. Exaggerated fighting game proportions on every fighter.
 
 ${tier.styleExtra}`;
   }
@@ -255,9 +255,14 @@ export async function POST(req: NextRequest) {
 
     // 6. Resize sprite and center on black canvas
     const CANVAS = 1024;
-    const spriteHeight = Math.round(CANVAS * 0.58); // bigger fighter
+    // Solo: fill ~58% of canvas height. Team: fit inside 95% of canvas so
+    // all fighters are visible regardless of how wide the scene is.
     const resized = await sharp(rawBuffer)
-      .resize({ height: spriteHeight, withoutEnlargement: false })
+      .resize(
+        photoMode === "team"
+          ? { width: Math.round(CANVAS * 0.95), height: Math.round(CANVAS * 0.75), fit: "inside", withoutEnlargement: false }
+          : { height: Math.round(CANVAS * 0.58), withoutEnlargement: false },
+      )
       .toBuffer();
 
     const meta = await sharp(resized).metadata();

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -123,13 +123,13 @@ function buildSpritePrompt(hoursIn: number, photoMode: "solo" | "team"): string 
   if (photoMode === "team") {
     return `Using every person visible in this group photo as character references, create a 2D pixel art cyberpunk fighting game scene in the style of Street Fighter II. Pure black backdrop.
 
-Render each person as their own distinct fighter standing side by side in a team battle formation — all facing the same direction, each in a dynamic fighting stance. Distinguish each fighter clearly with different hair, build, and stance matching the people in the photo.
+Render each person as their own distinct fighter standing side by side in a team battle formation — all facing the same direction, each in a dynamic fighting stance. Keep each fighter's facial likeness and hair faithful to the person in the photo.
 
 Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). Each character is ${tier.powerDesc}.
 
 Outfits: Preserve what each person is actually wearing in the photo, but reimagine it with cyberpunk street fighter flair — add ${accentDesc}, neon trim, tech panelling, armour plating, or glowing details while keeping the overall silhouette and style faithful to their real outfit. NOT karate gis or martial arts uniforms.
 
-All fighters fully visible from head to toe in a single wide scene. Exaggerated fighting game proportions on every fighter.
+Full team visible from head to toe. Exaggerated fighting game proportions on every fighter.
 
 ${tier.styleExtra}`;
   }

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -111,14 +111,18 @@ const POWER_TIERS: PowerTier[] = [
 function getPowerTier(hoursIn: number): PowerTier {
   if (hoursIn >= 23) return POWER_TIERS[3];
   if (hoursIn >= 16) return POWER_TIERS[2];
-  if (hoursIn >= 8)  return POWER_TIERS[1];
+  if (hoursIn >= 8) return POWER_TIERS[1];
   return POWER_TIERS[0];
 }
 
-function buildSpritePrompt(hoursIn: number, photoMode: "solo" | "team"): string {
-  const poseDesc   = POSES[Math.floor(Math.random() * POSES.length)];
-  const accentDesc = NEON_ACCENTS[Math.floor(Math.random() * NEON_ACCENTS.length)];
-  const tier       = getPowerTier(hoursIn);
+function buildSpritePrompt(
+  hoursIn: number,
+  photoMode: "solo" | "team",
+): string {
+  const poseDesc = POSES[Math.floor(Math.random() * POSES.length)];
+  const accentDesc =
+    NEON_ACCENTS[Math.floor(Math.random() * NEON_ACCENTS.length)];
+  const tier = getPowerTier(hoursIn);
 
   if (photoMode === "team") {
     return `Using every person visible in this group photo as character references, create a 2D pixel art cyberpunk fighting game scene in the style of Street Fighter II. Pure black backdrop.
@@ -260,7 +264,12 @@ export async function POST(req: NextRequest) {
     const resized = await sharp(rawBuffer)
       .resize(
         photoMode === "team"
-          ? { width: Math.round(CANVAS * 0.95), height: Math.round(CANVAS * 0.75), fit: "inside", withoutEnlargement: false }
+          ? {
+              width: Math.round(CANVAS * 0.95),
+              height: Math.round(CANVAS * 0.75),
+              fit: "inside",
+              withoutEnlargement: false,
+            }
           : { height: Math.round(CANVAS * 0.58), withoutEnlargement: false },
       )
       .toBuffer();

--- a/src/app/api/generate-sprite/route.ts
+++ b/src/app/api/generate-sprite/route.ts
@@ -64,17 +64,70 @@ const OUTFITS = [
   "trench coat with neon-lit panels, tactical belt, wide-leg combat trousers, steel-toe boots — orange and purple neon accents",
 ];
 
-function buildSpritePrompt(): string {
-  const poseDesc = POSES[Math.floor(Math.random() * POSES.length)];
+// ── Evolution tiers — power level scales with hours into the hackathon ────────
+
+interface PowerTier {
+  label: string;
+  powerDesc: string;
+  styleExtra: string;
+}
+
+const POWER_TIERS: PowerTier[] = [
+  {
+    // 0–7 h — Stage 1: Street Fighter
+    label: "Street Fighter",
+    powerDesc:
+      "sharp, confident, and fresh — a skilled street fighter at peak focus, clean and dangerous",
+    styleExtra:
+      "Bold black outlines, vibrant neon pixel art, clean retro Street Fighter II sprite style.",
+  },
+  {
+    // 8–15 h — Stage 2: Power Surge
+    label: "Power Surge",
+    powerDesc:
+      "mid-transformation — crackling electric energy bursting from their fists and eyes, glowing veins visible through skin, hair beginning to rise with static charge, power awakening inside them",
+    styleExtra:
+      "Bold black outlines, vibrant neon pixel art with electric sparks and glowing energy lines across the body. Street Fighter II sprite style.",
+  },
+  {
+    // 16–22 h — Stage 3: Super Form
+    label: "Super Form",
+    powerDesc:
+      "super-powered — a blazing aura of pure energy surrounds them, floating slightly off the ground, outfit partially disintegrating into streaks of neon light, eyes glowing solid white, overwhelming power barely contained",
+    styleExtra:
+      "Bold black outlines, vibrant neon pixel art. Large visible aura halo around the body, glowing energy trails. Exaggerated superhero proportions. Street Fighter II sprite style pushed to the limit.",
+  },
+  {
+    // 23 h+ — Stage 4: God Mode
+    label: "God Mode",
+    powerDesc:
+      "transcendent god form — part human, part pure radiant force, body erupting with divine energy, ethereal light trails streaming behind every limb, face serene and all-knowing, so powerful the very pixels around them seem to crack and glow",
+    styleExtra:
+      "Bold black outlines, vibrant neon pixel art at maximum intensity. Blinding white core with rainbow energy corona. Pixel art deity aesthetic — this character has ascended beyond human limits. Street Fighter II sprite style taken to godlike extremes.",
+  },
+];
+
+function getPowerTier(hoursIn: number): PowerTier {
+  if (hoursIn >= 23) return POWER_TIERS[3];
+  if (hoursIn >= 16) return POWER_TIERS[2];
+  if (hoursIn >= 8)  return POWER_TIERS[1];
+  return POWER_TIERS[0];
+}
+
+function buildSpritePrompt(hoursIn: number): string {
+  const poseDesc   = POSES[Math.floor(Math.random() * POSES.length)];
   const outfitDesc = OUTFITS[Math.floor(Math.random() * OUTFITS.length)];
+  const tier       = getPowerTier(hoursIn);
 
   return `Using the person in this photo as the character reference, create a 2D pixel art cyberpunk fighting game sprite in the style of Street Fighter II. Pure black backdrop.
+
+Evolution stage: ${tier.label} (${hoursIn}h into a 26-hour hackathon). The character is ${tier.powerDesc}.
 
 Outfit: ${outfitDesc}. Cyberpunk street fighter aesthetic — NOT a karate gi or martial arts uniform.
 
 Pose: Mid-attack — ${poseDesc}. Full body visible from head to toe, attacking limb fully extended. Exaggerated fighting game proportions, motion energy on the attacking limb.
 
-Bold black outlines, vibrant neon pixel art, clean retro Street Fighter sprite style.`;
+${tier.styleExtra}`;
 }
 
 // ── Route ────────────────────────────────────────────────────────────────────
@@ -114,7 +167,8 @@ export async function POST(req: NextRequest) {
   try {
     const formData = await req.formData();
     const file = formData.get("image") as File | null;
-    const SPRITE_PROMPT = buildSpritePrompt();
+    const hoursIn = Math.max(0, Number(formData.get("hoursIn") ?? 0));
+    const SPRITE_PROMPT = buildSpritePrompt(hoursIn);
 
     if (!file) {
       return NextResponse.json(

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -199,8 +199,8 @@ async function compositeAsset(
   ctx.fillStyle = "#000000";
   ctx.fillRect(0, 0, W, H);
 
-  // 2. Radial speed lines (brand colour palette)
-  drawRadialLines(ctx, W, H, palette);
+  // 2. Pixel-art grid on pure black
+  drawGridBackground(ctx, W, H);
 
   // 3. Sprite — strip black bg so lines show through behind the character
   const spriteOff = document.createElement("canvas");
@@ -285,29 +285,31 @@ function drawTitle(ctx: CanvasRenderingContext2D, W: number) {
 }
 
 // Crisp alternating radial speed lines — drawn on black bg before the sprite
-function drawRadialLines(
+// Pixel-art grid background — pure black with subtle dark grid lines
+function drawGridBackground(
   ctx: CanvasRenderingContext2D,
   W: number,
   H: number,
-  palette: BgPalette,
 ) {
-  const cx = W * 0.44;
-  const cy = H * 0.46;
-  const numRays = 20;
-  const maxR = Math.hypot(W, H);
+  const CELL = Math.round(W * 0.04); // ~40px grid cells at 1024px
 
   ctx.save();
-  for (let i = 0; i < numRays; i++) {
-    const startAngle = (i / numRays) * Math.PI * 2;
-    const endAngle = ((i + 0.5) / numRays) * Math.PI * 2;
+  ctx.strokeStyle = "rgba(180,180,180,0.18)";
+  ctx.lineWidth = 1;
 
+  for (let x = 0; x <= W; x += CELL) {
     ctx.beginPath();
-    ctx.moveTo(cx, cy);
-    ctx.arc(cx, cy, maxR, startAngle, endAngle);
-    ctx.closePath();
-    ctx.fillStyle = i % 2 === 0 ? palette.light : palette.dark;
-    ctx.fill();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, H);
+    ctx.stroke();
   }
+  for (let y = 0; y <= H; y += CELL) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(W, y);
+    ctx.stroke();
+  }
+
   ctx.restore();
 }
 

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -1075,16 +1075,59 @@ export default function SpriteGenPage() {
             className="w-full font-body text-sm text-[#e0e0e0] bg-black p-3 border border-[#2a2820] resize-none focus:outline-none focus:border-[#4EF9BD] mb-3"
           />
 
-          <button
-            onClick={handleCopy}
-            className={`font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#4EF9BD] transition-colors ${
-              copied
-                ? "bg-[#4EF9BD] text-black"
-                : "bg-transparent text-[#4EF9BD]"
-            }`}
-          >
-            {copied ? "Copied!" : "Copy text"}
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={handleCopy}
+              className={`font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#4EF9BD] transition-colors ${
+                copied
+                  ? "bg-[#4EF9BD] text-black"
+                  : "bg-transparent text-[#4EF9BD]"
+              }`}
+            >
+              {copied ? "Copied!" : "Copy text"}
+            </button>
+
+            {/* Share to X */}
+            <a
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(activePost)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-white hover:text-white transition-colors flex items-center gap-2"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.74l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+              Share on X
+            </a>
+
+            {/* Share to LinkedIn */}
+            <a
+              href="https://www.linkedin.com/feed/"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => navigator.clipboard.writeText(activePost)}
+              className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-[#0A66C2] hover:text-[#0A66C2] transition-colors flex items-center gap-2"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+              </svg>
+              Share on LinkedIn
+            </a>
+          </div>
+          <p className="font-body text-[10px] text-[#444440] mt-2">
+            LinkedIn: text copied to clipboard — paste it into your post.
+            Download your sprite to attach it.
+          </p>
         </div>
       </div>
     </div>

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -294,8 +294,8 @@ function drawGridBackground(
   const CELL = Math.round(W * 0.04); // ~40px grid cells at 1024px
 
   ctx.save();
-  ctx.strokeStyle = "rgba(160,160,160,0.45)";
-  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = "rgba(160,160,160,0.12)";
+  ctx.lineWidth = 1;
 
   for (let x = 0; x <= W; x += CELL) {
     ctx.beginPath();

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -454,9 +454,7 @@ function drawStatsPanel(
   drawLabel("SECTOR", sectorDisplay);
 
   // ── Row 3: Team size ───────────────────────────────────────────────────
-  const teamLabel = ["SOLO", "DUO", "TRIO", "SQUAD"][
-    Math.min(stats.teamSize - 1, 3)
-  ];
+  const teamLabel = ["SOLO", "DUO", "TRIO"][Math.min(stats.teamSize - 1, 2)];
   drawLabel("TEAM", teamLabel);
 
   // ── Row 4: Stage progress bar ──────────────────────────────────────────
@@ -901,7 +899,7 @@ export default function SpriteGenPage() {
               Team size
             </label>
             <div className="flex gap-2">
-              {[1, 2, 3, 4].map((n) => (
+              {[1, 2, 3].map((n) => (
                 <button
                   key={n}
                   onClick={() => setTeamSize(n)}
@@ -911,13 +909,7 @@ export default function SpriteGenPage() {
                       : "border-[#2a2820] text-[#888880] hover:border-[#4EF9BD]/50"
                   }`}
                 >
-                  {n === 1
-                    ? "Solo"
-                    : n === 2
-                      ? "Duo"
-                      : n === 3
-                        ? "Trio"
-                        : "Squad"}
+                  {n === 1 ? "Solo" : n === 2 ? "Duo" : "Trio"}
                 </button>
               ))}
             </div>

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -622,9 +622,6 @@ export default function SpriteGenPage() {
   const [loading, setLoading] = useState(false);
   const [selectedVariant, setSelectedVariant] = useState(0);
 
-  // ── Photo mode ───────────────────────────────────────────────────────────
-  const [photoMode, setPhotoMode] = useState<"solo" | "team">("solo");
-
   // ── Hackathon stats ──────────────────────────────────────────────────────
   const [sector, setSector] = useState("");
   const [teamSize, setTeamSize] = useState(1);
@@ -678,7 +675,7 @@ export default function SpriteGenPage() {
       formData.append("image", uploadedFile);
       formData.append("tools", JSON.stringify(selectedTools));
       formData.append("hoursIn", String(snap.h));
-      formData.append("photoMode", photoMode);
+      formData.append("photoMode", "solo");
 
       const res = await fetch("/api/generate-sprite", {
         method: "POST",
@@ -756,28 +753,6 @@ export default function SpriteGenPage() {
           <h2 className="font-title text-sm text-white uppercase tracking-wider mb-4">
             Upload your photo
           </h2>
-
-          {/* Solo / Team toggle */}
-          <div className="flex gap-2 mb-4">
-            {(["solo", "team"] as const).map((mode) => (
-              <button
-                key={mode}
-                onClick={() => setPhotoMode(mode)}
-                className={`font-title text-xs uppercase tracking-wider px-4 py-2 border transition-all ${
-                  photoMode === mode
-                    ? "border-[#B307EB] bg-[#B307EB]/10 text-[#B307EB]"
-                    : "border-[#2a2820] text-[#888880] hover:border-[#B307EB]/50"
-                }`}
-              >
-                {mode === "solo" ? "⚡ Solo" : "👥 Team"}
-              </button>
-            ))}
-          </div>
-          <p className="font-body text-xs text-[#555550] mb-4">
-            {photoMode === "solo"
-              ? "Upload a photo of yourself — you'll be rendered as a solo fighter."
-              : "Upload a group photo — everyone gets rendered as their own fighter."}
-          </p>
 
           {!previewSrc ? (
             <label

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -294,8 +294,8 @@ function drawGridBackground(
   const CELL = Math.round(W * 0.04); // ~40px grid cells at 1024px
 
   ctx.save();
-  ctx.strokeStyle = "rgba(180,180,180,0.18)";
-  ctx.lineWidth = 1;
+  ctx.strokeStyle = "rgba(160,160,160,0.45)";
+  ctx.lineWidth = 1.5;
 
   for (let x = 0; x <= W; x += CELL) {
     ctx.beginPath();

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -673,9 +673,11 @@ export default function SpriteGenPage() {
     setStatus("Generating your sprite… (~30s)");
 
     try {
+      const snap = getElapsed(); // snapshot at generation time
       const formData = new FormData();
       formData.append("image", uploadedFile);
       formData.append("tools", JSON.stringify(selectedTools));
+      formData.append("hoursIn", String(snap.h));
 
       const res = await fetch("/api/generate-sprite", {
         method: "POST",
@@ -695,7 +697,6 @@ export default function SpriteGenPage() {
       // Pick a random brand palette each generation
       const palette =
         BG_PALETTES[Math.floor(Math.random() * BG_PALETTES.length)];
-      const snap = getElapsed(); // snapshot at generation time
       const finalUrl = await compositeAsset(imageUrl, selectedTools, palette, {
         sector,
         teamSize,

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -294,7 +294,7 @@ function drawGridBackground(
   const CELL = Math.round(W * 0.04); // ~40px grid cells at 1024px
 
   ctx.save();
-  ctx.strokeStyle = "rgba(160,160,160,0.12)";
+  ctx.strokeStyle = "rgba(160,160,160,0.22)";
   ctx.lineWidth = 1;
 
   for (let x = 0; x <= W; x += CELL) {

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -625,6 +625,9 @@ export default function SpriteGenPage() {
   const [loading, setLoading] = useState(false);
   const [selectedVariant, setSelectedVariant] = useState(0);
 
+  // ── Photo mode ───────────────────────────────────────────────────────────
+  const [photoMode, setPhotoMode] = useState<"solo" | "team">("solo");
+
   // ── Hackathon stats ──────────────────────────────────────────────────────
   const [sector, setSector] = useState("");
   const [teamSize, setTeamSize] = useState(1);
@@ -678,6 +681,7 @@ export default function SpriteGenPage() {
       formData.append("image", uploadedFile);
       formData.append("tools", JSON.stringify(selectedTools));
       formData.append("hoursIn", String(snap.h));
+      formData.append("photoMode", photoMode);
 
       const res = await fetch("/api/generate-sprite", {
         method: "POST",
@@ -755,6 +759,28 @@ export default function SpriteGenPage() {
           <h2 className="font-title text-sm text-white uppercase tracking-wider mb-4">
             Upload your photo
           </h2>
+
+          {/* Solo / Team toggle */}
+          <div className="flex gap-2 mb-4">
+            {(["solo", "team"] as const).map((mode) => (
+              <button
+                key={mode}
+                onClick={() => setPhotoMode(mode)}
+                className={`font-title text-xs uppercase tracking-wider px-4 py-2 border transition-all ${
+                  photoMode === mode
+                    ? "border-[#B307EB] bg-[#B307EB]/10 text-[#B307EB]"
+                    : "border-[#2a2820] text-[#888880] hover:border-[#B307EB]/50"
+                }`}
+              >
+                {mode === "solo" ? "⚡ Solo" : "👥 Team"}
+              </button>
+            ))}
+          </div>
+          <p className="font-body text-xs text-[#555550] mb-4">
+            {photoMode === "solo"
+              ? "Upload a photo of yourself — you'll be rendered as a solo fighter."
+              : "Upload a group photo — everyone gets rendered as their own fighter."}
+          </p>
 
           {!previewSrc ? (
             <label

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -328,10 +328,12 @@ function removeSpriteBackground(
     [0, h - 1],
     [w - 1, h - 1],
   ];
-  let bgR = 0, bgG = 0, bgB = 0;
+  let bgR = 0,
+    bgG = 0,
+    bgB = 0;
   for (const [cx, cy] of corners) {
     const idx = (cy * w + cx) * 4;
-    bgR += d[idx]     / 4;
+    bgR += d[idx] / 4;
     bgG += d[idx + 1] / 4;
     bgB += d[idx + 2] / 4;
   }
@@ -339,7 +341,7 @@ function removeSpriteBackground(
   // Remove pixels whose colour is close to the sampled background
   const THRESHOLD = 72; // colour-distance tolerance (0–441)
   for (let i = 0; i < d.length; i += 4) {
-    const dr = d[i]     - bgR;
+    const dr = d[i] - bgR;
     const dg = d[i + 1] - bgG;
     const db = d[i + 2] - bgB;
     if (Math.sqrt(dr * dr + dg * dg + db * db) < THRESHOLD) {

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -118,9 +118,8 @@ const SLEEP_FILL: Record<Sleep, number> = {
   Fumes: 0.12,
 };
 
-// Hackathon kicked off at 11:00 AM local time on the event day (April 25 2026)
-const HACKATHON_START = new Date();
-HACKATHON_START.setHours(11, 0, 0, 0);
+// Hackathon kicked off at 11:00 AM on April 25 2026
+const HACKATHON_START = new Date(2026, 3, 25, 11, 0, 0, 0); // month is 0-indexed
 
 function getElapsed(): { h: number; m: number } {
   const ms = Date.now() - HACKATHON_START.getTime();
@@ -199,8 +198,8 @@ async function compositeAsset(
   ctx.fillStyle = "#000000";
   ctx.fillRect(0, 0, W, H);
 
-  // 2. Pixel-art grid on pure black
-  drawGridBackground(ctx, W, H);
+  // 2. Radial speed lines — brand colour palette
+  drawRadialLines(ctx, W, H, palette);
 
   // 3. Sprite — strip black bg so lines show through behind the character
   const spriteOff = document.createElement("canvas");
@@ -285,31 +284,29 @@ function drawTitle(ctx: CanvasRenderingContext2D, W: number) {
 }
 
 // Crisp alternating radial speed lines — drawn on black bg before the sprite
-// Pixel-art grid background — pure black with subtle dark grid lines
-function drawGridBackground(
+// Radial speed-line background — brand palette wedges radiating from centre
+function drawRadialLines(
   ctx: CanvasRenderingContext2D,
   W: number,
   H: number,
+  palette: BgPalette,
 ) {
-  const CELL = Math.round(W * 0.04); // ~40px grid cells at 1024px
+  const cx = W * 0.44;
+  const cy = H * 0.46;
+  const numRays = 20;
+  const maxR = Math.hypot(W, H);
 
   ctx.save();
-  ctx.strokeStyle = "rgba(160,160,160,0.22)";
-  ctx.lineWidth = 1;
-
-  for (let x = 0; x <= W; x += CELL) {
+  for (let i = 0; i < numRays; i++) {
+    const startAngle = (i / numRays) * Math.PI * 2;
+    const endAngle = ((i + 0.5) / numRays) * Math.PI * 2;
     ctx.beginPath();
-    ctx.moveTo(x, 0);
-    ctx.lineTo(x, H);
-    ctx.stroke();
+    ctx.moveTo(cx, cy);
+    ctx.arc(cx, cy, maxR, startAngle, endAngle);
+    ctx.closePath();
+    ctx.fillStyle = i % 2 === 0 ? palette.light : palette.dark;
+    ctx.fill();
   }
-  for (let y = 0; y <= H; y += CELL) {
-    ctx.beginPath();
-    ctx.moveTo(0, y);
-    ctx.lineTo(W, y);
-    ctx.stroke();
-  }
-
   ctx.restore();
 }
 

--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -313,8 +313,9 @@ function drawGridBackground(
   ctx.restore();
 }
 
-// Remove pure-black background from the sprite so the bg shows through.
-// Pixel art sprites have solid #000 bg; character darks always have some colour.
+// Remove the sprite background regardless of what colour Gemini chose.
+// Samples the four corners to detect the actual bg colour, then removes
+// any pixel within `THRESHOLD` colour-distance of that sampled colour.
 function removeSpriteBackground(
   offCtx: CanvasRenderingContext2D,
   w: number,
@@ -322,11 +323,33 @@ function removeSpriteBackground(
 ) {
   const imageData = offCtx.getImageData(0, 0, w, h);
   const d = imageData.data;
+
+  // Average the four corner pixels to get the background colour
+  const corners = [
+    [0, 0],
+    [w - 1, 0],
+    [0, h - 1],
+    [w - 1, h - 1],
+  ];
+  let bgR = 0, bgG = 0, bgB = 0;
+  for (const [cx, cy] of corners) {
+    const idx = (cy * w + cx) * 4;
+    bgR += d[idx]     / 4;
+    bgG += d[idx + 1] / 4;
+    bgB += d[idx + 2] / 4;
+  }
+
+  // Remove pixels whose colour is close to the sampled background
+  const THRESHOLD = 72; // colour-distance tolerance (0–441)
   for (let i = 0; i < d.length; i += 4) {
-    if (d[i] < 18 && d[i + 1] < 18 && d[i + 2] < 18) {
-      d[i + 3] = 0; // transparent
+    const dr = d[i]     - bgR;
+    const dg = d[i + 1] - bgG;
+    const db = d[i + 2] - bgB;
+    if (Math.sqrt(dr * dr + dg * dg + db * db) < THRESHOLD) {
+      d[i + 3] = 0;
     }
   }
+
   offCtx.putImageData(imageData, 0, 0);
 }
 


### PR DESCRIPTION
## Summary

- **4-stage power evolution** tied to hours elapsed since hackathon start (11 AM Apr 25). Street Fighter → Power Surge → Super Form → God Mode — Gemini receives a different power-level prompt at each tier
- **Game HUD stats panel** (top-left): live hackathon timer, sector free-text, team size (Solo/Duo/Trio), segmented stage progress bar, sleep health bar (green→yellow→red)
- **Sponsor tool icon slots** (bottom-right): pixel-art game inventory panel with palette-matched accent borders
- **Outfit preservation**: Gemini now reads the person's actual clothing from the photo and adds cyberpunk flair on top, rather than using random preset outfits
- **Radial wheel background**: brand-colour speed lines (purple/blue/green/red palettes rotating per generation), all HUD panels and borders use the same palette for consistency
- **Smart background removal**: samples four corner pixels to detect whatever background colour Gemini generates and removes it, regardless of hue
- **Hackathon timer**: hardcoded to Apr 25 2026 11:00 AM, live-updates every minute in UI
- **Cleanup**: removed team photo toggle, Squad team size option, fireball explosion logos, unused code

## Test plan

- [ ] Upload a photo → generate → verify radial background colour matches HUD panel borders
- [ ] Verify timer shows correct elapsed time since 11 AM Apr 25
- [ ] Fill in sector, change team size / stage / sleep → regenerate → verify HUD reflects changes
- [ ] Generate multiple times → verify pose, neon accent, and background palette all vary
- [ ] Simulate hours 3 / 10 / 18 / 24 → verify 4 power tiers look distinct
- [ ] Select 1–3 sponsors → verify icon slots render in bottom-right
- [ ] `npm run lint` and `npm run build` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time-based evolution/tier system unlocking new character variations, effects, and tier-specific styling
  * Share toolbar on posts (X and LinkedIn) with clipboard helper and download guidance

* **Changes**
  * Randomized neon accent colors for sprites
  * Improved sprite background removal via adaptive corner-color detection
  * Team size options limited to Solo, Duo, Trio
  * Team images now scale to ensure full group visibility; solo images retain previous scaling

* **Bug Fixes**
  * Corrected elapsed-time anchoring for consistent generation timing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->