### PR TITLE
fix(spritegen): always show both share buttons, fix LinkedIn tag & timer

### DIFF
--- a/src/app/spritegen/page.tsx
+++ b/src/app/spritegen/page.tsx
@@ -25,7 +25,7 @@ function getPostVariants(
   const names = toolIds
     .map((id) => toolOptions.find((t) => t.id === id)?.label ?? id)
     .join(", ");
-  const tag = platform === "x" ? "@unicorn_mafia" : "unicorn-mafia";
+  const tag = platform === "x" ? "@unicorn_mafia" : "@unicorn-mafia";
   return [
     `We're cooking. 🔥
 
@@ -1132,49 +1132,48 @@ export default function SpriteGenPage() {
               {copied ? "Copied!" : "Copy text"}
             </button>
 
-            {platform === "x" ? (
-              <a
-                href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(activePost)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-white hover:text-white transition-colors flex items-center gap-2"
+            <a
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(xVariants[selectedVariant] ?? xVariants[0])}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-white hover:text-white transition-colors flex items-center gap-2"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
               >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.74l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-                Share on X
-              </a>
-            ) : (
-              <a
-                href="https://www.linkedin.com/feed/"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => navigator.clipboard.writeText(activePost)}
-                className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-[#0A66C2] hover:text-[#0A66C2] transition-colors flex items-center gap-2"
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.74l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+              Share on X
+            </a>
+            <a
+              href="https://www.linkedin.com/feed/"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() =>
+                navigator.clipboard.writeText(
+                  linkedInVariants[selectedVariant] ?? linkedInVariants[0],
+                )
+              }
+              className="font-title text-sm uppercase tracking-wider px-5 py-2 border border-[#888880] text-[#888880] hover:border-[#0A66C2] hover:text-[#0A66C2] transition-colors flex items-center gap-2"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
               >
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                </svg>
-                Share on LinkedIn
-              </a>
-            )}
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+              </svg>
+              Share on LinkedIn
+            </a>
           </div>
-          {platform === "linkedin" && (
-            <p className="font-body text-[10px] text-[#444440] mt-2">
-              Text copied to clipboard — paste into your post and attach your
-              downloaded sprite.
-            </p>
-          )}
+          <p className="font-body text-[10px] text-[#444440] mt-2">
+            LinkedIn: text copied to clipboard — paste into your post and attach
+            your downloaded sprite.
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Both **Share on X** and **Share on LinkedIn** buttons now always visible (previously only one showed based on platform toggle)
- X uses `@unicorn_mafia`, LinkedIn uses `@unicorn-mafia` (added missing `@`)
- Platform toggle still controls which text variant is previewed in the box
- LinkedIn hint text always visible since the button is always there
- Timer confirmed correct — counts from 11AM April 25 2026

## Test plan

- [ ] Both share buttons visible regardless of platform toggle selection
- [ ] Share on X opens `twitter.com/intent/tweet` with `@unicorn_mafia` in text
- [ ] Share on LinkedIn opens `linkedin.com/feed` and copies text with `@unicorn-mafia`
- [ ] Platform toggle (X / LinkedIn) still switches the preview text
- [ ] Timer shows correct elapsed hours (24h+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured social share controls to always display X and LinkedIn sharing options.

* **Style**
  * Updated share messaging for improved clarity and consistency.
  * Enhanced platform tag formatting in shared content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->